### PR TITLE
Fix 10 bugs from code review of PR #64 + add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+**Espace-Image** — a FastAPI slideshow application that displays uploaded photos, calendar alarms, and weather on internal-network devices. It has two UIs: a modern frontend and a **legacy UI** for iPad 2 (iOS 9.3.5, ES5-only, no CSS Grid).
+
+## Commands
+
+```bash
+# Install dependencies (uv only — never use pip directly)
+uv sync --dev
+
+# Run the app
+uv run uvicorn app.main:app --reload
+
+# Tests (single test: add -k "test_name")
+uv run pytest tests/ -v --cov=app --cov-report=xml
+
+# Python lint / format
+uv run ruff check .
+uv run ruff format .
+
+# HTML/CSS/JS lint
+npm run lint
+npm run lint:fix   # auto-fix CSS/JS
+```
+
+### espima CLI (database + CalDAV)
+
+```bash
+uv run espima db init          # initialize tables and seed defaults
+uv run espima db migrate       # apply Alembic migrations
+uv run espima caldav list --url <url> --username <u> --password <p>
+uv run espima caldav add --index 1 --url <url> --username <u> --password <p>
+uv run espima caldav sync
+```
+
+## Architecture
+
+**Modular monolith with hexagonal architecture and API/GUI split.**
+
+### Layer Map
+
+```
+app/main.py                   # Entry point, APScheduler, lifespan hooks
+app/modules/loader.py         # Composition root — wires all modules into FastAPI
+app/routers/                  # Thin HTTP adapters (request parsing → DI → response)
+app/modules/<name>/
+  api/interfaces.py           # Public contracts (I<Name>Service, get_<name>_service)
+  api/schemas.py              # Transport-agnostic DTOs
+  internal/application/       # Business logic — returns DTOs only, never HTML
+  internal/infrastructure/    # HTTP clients, file ops, DB helpers, presenter.py
+app/db/                       # SQLModel ORM on SQLite, UTC storage
+app/templates/                # Jinja2 (partials/ for HTMX fragments, legacy/ for iPad 2)
+```
+
+### Current Modules
+
+| Module | Purpose |
+|---|---|
+| `calendar` | ICS ingestion via CalDAV, recurrence expansion (icalevents), event cache |
+| `alarms` | Active alarm assembly, dismissal, 30-day purge |
+| `weather` | Open-Meteo fetch + Nominatim geocoding |
+| `media` | Upload validation (extension + magic bytes), Pillow optimization |
+| `settings` | App settings persistence |
+| `slideshow` | Current slide selection and preset rotation |
+
+## Non-Negotiable Rules
+
+1. **Services return DTOs only.** Application services (`internal/application/`) never render HTML.
+2. **Presenters render HTML.** Each module has `internal/infrastructure/presenter.py`; only routers call presenters.
+3. **No `app/services/`.** That directory was deleted intentionally. Do not recreate it.
+4. **Routers stay thin.** Request parsing → `Depends(get_<module>_service)` → DTO → presenter → response. No business logic.
+5. **UTC in storage.** DB writes and file storage paths use UTC. Convert to user timezone only at render time.
+6. **iPad 2 legacy path.** Templates in `app/templates/legacy/` and JS in `app/static/js/` must stay ES5-compatible and CSS-Grid-free.
+7. **New modules follow the same structure.** Always include `presenter.py` with at least one unit test.
+
+## Route Conventions
+
+- API endpoints: `service.get_data() → DTO → JSONResponse(dto.dict())`
+- GUI endpoints: `service.get_data() → DTO → presenter.render(dto) → TemplateResponse`
+- Inject DB sessions via `Depends(get_session)`, module services via `Depends(get_<module>_service)`
+- Tests: use dependency overrides, not internal patching
+
+## Scheduler Exception
+
+`app/main.py` may instantiate `CalendarApplicationService` directly for background sync (APScheduler runs outside request-scoped FastAPI DI). Keep this exception narrow.
+
+## Frontend
+
+- Admin UI is HTMX-driven; routes return HTML fragments (`partials/`)
+- Weather and alarm widgets refresh every 5 minutes via `/components/index-refresh` (out-of-band HTMX fragments)
+- `INDEX_UPDATE_INTERVAL_SECONDS` is set in `app/main.py` and passed to templates as `index_update_interval_seconds`
+- No inline event handlers; JS lives in `app/static/js/`
+
+## Calendar Integration
+
+- ICS sources: `CalendarSource` model
+- Cached events: `CalendarEventCache`
+- Sync status: `CalendarSyncStatusEntry`
+- All recurrence logic uses `icalevents` (the older `icalendar` dependency has been removed)
+- All-day events are date-safe (not timezone-shifted)
+
+## Documentation Maintenance
+
+When module boundaries or infrastructure ownership changes, update all of these:
+- `.github/copilot-instructions.md`
+- `CODEBASE_EXPLORATION_SUMMARY.md`
+- `memory-bank/systemPatterns.md`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `.specs/codebase/*.md` if they describe current structure
+
+## Key Reference Files
+
+- `docs/ADR/` — Architecture Decision Records
+- `docs/db/DB.md` — Database schema
+- `docs/LLM_ARCHITECTURE_INSTRUCTIONS.md` — Detailed presenter pattern guidance
+- `.specs/codebase/ARCHITECTURE.md` — Full architectural patterns
+- `.specs/codebase/TESTING.md` — Test infrastructure patterns
+- `memory-bank/systemPatterns.md` — Canonical patterns doc

--- a/app/config.py
+++ b/app/config.py
@@ -48,14 +48,12 @@ CALDAV_VERIFY_SSL = os.getenv("CALDAV_VERIFY_SSL", "true").lower() in ("true", "
 # This allows throttling requests when multiple calendars are configured.
 # Value is in minutes and may be fractional (e.g. 0.5 = 30 seconds). Default: 0 (no delay).
 BACKGROUND_SYNC_DELAY_MINUTES = float(os.getenv("BACKGROUND_SYNC_DELAY_MINUTES", "0"))
-# Default delay (minutes) used when BACKGROUND_SYNC_DELAY_MINUTES is unset or <= 0
+# Total background sync cycle period in minutes (how often the scheduler fires).
+# BACKGROUND_SYNC_DELAY_MINUTES is only the per-source throttle between individual
+# calendar fetches; it does NOT control the overall cycle length.
 BACKGROUND_SYNC_DEFAULT_MINUTES = int(os.getenv("BACKGROUND_SYNC_DEFAULT_MINUTES", "120"))
 
-# Effective backend sync period in minutes (the real cycle length)
-_effective_sync_minutes: float = (
-    BACKGROUND_SYNC_DELAY_MINUTES
-    if BACKGROUND_SYNC_DELAY_MINUTES and BACKGROUND_SYNC_DELAY_MINUTES > 0
-    else BACKGROUND_SYNC_DEFAULT_MINUTES
-)
+# Effective backend sync period is always the configured cycle length.
+_effective_sync_minutes: float = float(BACKGROUND_SYNC_DEFAULT_MINUTES)
 # Frontend event/alarm refresh interval: half the backend sync period, minimum 1 minute.
 FRONTEND_DAY_FETCH_INTERVAL_MS = int(max(60_000, _effective_sync_minutes / 2 * 60 * 1000))

--- a/app/main.py
+++ b/app/main.py
@@ -10,10 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 # Import configuration constants
-from app.config import (
-    BACKGROUND_SYNC_DEFAULT_MINUTES,
-    BACKGROUND_SYNC_DELAY_MINUTES,
-)
+from app.config import BACKGROUND_SYNC_DEFAULT_MINUTES
 from app.db.session_factory import SessionFactory
 from app.modules.alarms.rest import router as alarms_rest_router
 from app.modules.calendar.loader import build_calendar_service
@@ -133,11 +130,7 @@ async def background_sync_calendars() -> None:
 
 
 def _sync_period_minutes() -> float:
-    return (
-        BACKGROUND_SYNC_DELAY_MINUTES
-        if BACKGROUND_SYNC_DELAY_MINUTES and BACKGROUND_SYNC_DELAY_MINUTES > 0
-        else BACKGROUND_SYNC_DEFAULT_MINUTES
-    )
+    return float(BACKGROUND_SYNC_DEFAULT_MINUTES)
 
 
 @asynccontextmanager

--- a/app/modules/calendar/api/sync_gateway.py
+++ b/app/modules/calendar/api/sync_gateway.py
@@ -11,8 +11,13 @@ from app.modules.calendar.api.contracts import CalendarSyncReportDTO
 class ICalendarSyncGateway(Protocol):
     """Infrastructure gateway for calendar synchronization and ICS fetches."""
 
-    async def sync_calendar_events(self, session: Session) -> None:
-        """Sync all configured calendar events using the given session."""
+    async def sync_calendar_events(self, session: Session, force: bool = False) -> None:
+        """Sync all configured calendar events using the given session.
+
+        Args:
+            force: When True, force a full resync for all sources even if CalDAV
+                indicates no changes.
+        """
         ...
 
     async def sync_calendar_events_with_report(

--- a/app/modules/calendar/internal/infrastructure/alarm_normalizer.py
+++ b/app/modules/calendar/internal/infrastructure/alarm_normalizer.py
@@ -17,7 +17,7 @@ from sqlmodel import Session, select
 from app.db.models import AlarmEntryType, AlarmEvent, CalendarElement, CalendarSource
 from app.modules.calendar.internal.infrastructure.calendar_sync import (
     CalendarService,
-    _is_apple_source,
+    is_apple_source,
 )
 from app.utils.timezone import normalize_datetime
 
@@ -132,7 +132,7 @@ class CalendarAlarmNormalizer:
                 source_id = element.calendar_source_id
                 source = source_by_id.get(source_id)
                 fix_icloud = bool(
-                    source and _is_apple_source(os.environ.get("CALDAV_PROVIDER"), source.url)
+                    source and is_apple_source(os.environ.get("CALDAV_PROVIDER"), source.url)
                 )
                 events = CalendarService.parse_ics_events(
                     element.raw_ics,

--- a/app/modules/calendar/internal/infrastructure/caldav_client.py
+++ b/app/modules/calendar/internal/infrastructure/caldav_client.py
@@ -78,16 +78,21 @@ def _normalize_calendar_url(url: str) -> str:
 
 
 def _same_calendar_url(left: str, right: str) -> bool:
-    """Return True when two URLs refer to the same CalDAV calendar."""
+    """Return True when two URLs refer to the same CalDAV calendar.
+
+    Compares full normalized URLs first, then falls back to path-segment
+    equality. Substring containment is intentionally avoided — it would
+    incorrectly match /calendars/home against /calendars/home-work.
+    """
     normalized_left = _normalize_calendar_url(left)
     normalized_right = _normalize_calendar_url(right)
     if not normalized_left or not normalized_right:
         return False
-    return (
-        normalized_left == normalized_right
-        or normalized_left in normalized_right
-        or normalized_right in normalized_left
-    )
+    if normalized_left == normalized_right:
+        return True
+    left_path = urlparse(normalized_left).path.rstrip("/")
+    right_path = urlparse(normalized_right).path.rstrip("/")
+    return bool(left_path and right_path and left_path == right_path)
 
 
 def _find_matching_calendar(calendars: list[Any], target_calendar: str) -> Any | None:

--- a/app/modules/calendar/internal/infrastructure/calendar_sync.py
+++ b/app/modules/calendar/internal/infrastructure/calendar_sync.py
@@ -48,7 +48,7 @@ def _is_apple_ical_url(url: str | None) -> bool:
         return "icloud.com" in (url or "")
 
 
-def _is_apple_source(provider: str | None, url: str | None) -> bool:
+def is_apple_source(provider: str | None, url: str | None) -> bool:
     """Prefer `provider` when present, otherwise fall back to URL heuristics."""
     if provider:
         try:
@@ -553,7 +553,7 @@ class CalendarService:
         all_alarms: list[dict[str, Any]] = []
         for (source_id, url), content in zip(sources, results, strict=False):
             if content:
-                fix_icloud = _is_apple_source(_env_provider(), url)
+                fix_icloud = is_apple_source(_env_provider(), url)
                 alarms = CalendarService.get_upcoming_alarms(
                     content,
                     check_time,
@@ -944,9 +944,6 @@ class CalendarService:
         session: Session,
         source_id: int,
         elements: list[dict[str, str | None]],
-        window_start: datetime,
-        window_end: datetime,
-        fix_icloud: bool = False,
     ) -> None:
         for element in elements:
             uid = element.get("uid") or ""
@@ -960,9 +957,6 @@ class CalendarService:
                 fallback_uid=uid,
                 href=element.get("href") or "",
                 etag=element.get("etag"),
-                window_start=window_start,
-                window_end=window_end,
-                fix_icloud=fix_icloud,
             )
             if not row_payloads:
                 session.add(
@@ -1084,12 +1078,8 @@ class CalendarService:
         fallback_uid: str,
         href: str,
         etag: str | None,
-        window_start: datetime,
-        window_end: datetime,
-        fix_icloud: bool = False,
     ) -> list[dict[str, Any]]:
         """Build persisted calendar element payloads from raw VEVENT data."""
-        del window_start, window_end, fix_icloud
 
         payload = CalendarService._wrap_raw_ics_as_calendar(raw_ics)
         try:
@@ -1315,8 +1305,7 @@ class CalendarService:
                             is_caldav=True,
                         )
                     else:
-                        # If forcing a full resync when CalDAV reports no change,
-                        # proceed to treat content as fetched and replace cache.
+                        # fetch_succeeded=True AND (changed=True OR force=True).
                         ics_content = caldav_result.content
                         raw_elements = [
                             {
@@ -1327,9 +1316,33 @@ class CalendarService:
                             }
                             for element in caldav_result.elements
                         ]
-                        # If force requested and CalDAV reported no change, mark changed=True
                         if force and not changed:
                             changed = True
+                        # When force=True and CalDAV correctly reports no changes,
+                        # content is None (the server did not send a full payload).
+                        # Re-fetch without a sync token to obtain the full content.
+                        if force and ics_content is None:
+                            logger.info(
+                                "Force requested but CalDAV reported no changes for source %s (%s);"
+                                " re-fetching without sync token.",
+                                source.id,
+                                source.label,
+                            )
+                            fresh_result = await fetch_caldav_calendar_ics_with_metadata(
+                                calendar_url=source.url,
+                                sync_token=None,
+                                fail_on_error=False,
+                            )
+                            ics_content = fresh_result.content
+                            raw_elements = [
+                                {
+                                    "uid": el.uid,
+                                    "href": el.href,
+                                    "etag": el.etag,
+                                    "raw_ics": el.raw_ics,
+                                }
+                                for el in fresh_result.elements
+                            ]
                 else:
                     ics_content = await CalendarService.fetch_ics(source.url)
                     if ics_content is not None:
@@ -1378,9 +1391,6 @@ class CalendarService:
                 session,
                 source_id,
                 raw_elements,
-                window_start=window_start,
-                window_end=window_end,
-                fix_icloud=_is_apple_source(_env_provider(), source.url),
             )
 
             session.commit()

--- a/app/modules/calendar/internal/infrastructure/repository.py
+++ b/app/modules/calendar/internal/infrastructure/repository.py
@@ -1,6 +1,5 @@
 """Calendar repository adapter for SQLModel persistence."""
 
-import contextlib
 from datetime import datetime
 
 from sqlmodel import Session, select
@@ -84,11 +83,6 @@ class CalendarRepository(ICalendarRepository):
             session.delete(al)
 
         session.commit()
-
-        # After cleaning the specific source, also run an orphan cleanup to
-        # ensure no stray rows remain for deleted or missing sources.
-        with contextlib.suppress(Exception):
-            self.cleanup_orphans(session)
 
         return (len(statuses), len(elements), len(alarms))
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -247,9 +247,7 @@
                     } catch (e) {
                         console.error('formatAlarmTimes error', e);
                     }
-                    if (reason === 'init' || reason === 'sync-event') {
-                        refreshAlarmPoller(tzOffset);
-                    }
+                    refreshAlarmPoller(tzOffset);
                     scheduleNextAlarmCheck();
                     scheduleNextDayPayloadFetch();
                 })

--- a/app/templates/legacy/index.html
+++ b/app/templates/legacy/index.html
@@ -325,9 +325,9 @@
 <script>
     var CONFIG = {
         slideInterval: {{ settings.slideshow_duration or 30 }} * 1000,
-            weatherInterval: { { legacy_weather_interval_ms } },
-    alarmInterval: { { legacy_index_update_interval_ms } },
-    dayFetchIntervalMs: { { frontend_day_fetch_interval_ms } }
+            weatherInterval: {{ legacy_weather_interval_ms }},
+    alarmInterval: {{ legacy_index_update_interval_ms }},
+    dayFetchIntervalMs: {{ frontend_day_fetch_interval_ms }}
     };
 </script>
 

--- a/tests/test_calendar_alarm_normalizer.py
+++ b/tests/test_calendar_alarm_normalizer.py
@@ -52,8 +52,6 @@ END:VCALENDAR
                 "raw_ics": raw_ics,
             }
         ],
-        window_start=datetime(2026, 1, 1, tzinfo=UTC),
-        window_end=datetime(2026, 2, 1, tzinfo=UTC),
     )
     session.commit()
 

--- a/tests/test_calendar_repository_cleanup.py
+++ b/tests/test_calendar_repository_cleanup.py
@@ -82,8 +82,8 @@ def test_cleanup_orphans_deletes_orphan_rows(session):
     assert len(remaining_alarms) == 1
 
 
-def test_cleanup_source_runs_orphan_cleanup(session):
-    """cleanup_source should remove per-source rows and then run orphan cleanup as a best-effort."""
+def test_cleanup_source_does_not_run_orphan_cleanup(session):
+    """cleanup_source only removes per-source rows; orphan cleanup is a separate operation."""
     repo = CalendarRepository()
 
     # Create two sources, one to delete and one active
@@ -107,23 +107,14 @@ def test_cleanup_source_runs_orphan_cleanup(session):
     session.add_all([status_td, elem_td, alarm_td, orphan_status])
     session.commit()
 
-    # Ensure orphan exists
-    orphans_before = list(
-        session.exec(
-            select(CalendarSyncStatusEntry).where(
-                CalendarSyncStatusEntry.calendar_source_id == 9999
-            )
-        ).all()
-    )
-    assert len(orphans_before) == 1
-
-    # Run per-source cleanup
+    # Run per-source cleanup — should remove only the target source's rows
     counts = repo.cleanup_source(session, to_delete.id)
     assert counts[0] == 1
     assert counts[1] == 1
     assert counts[2] == 1
 
-    # Orphan should be removed as part of cleanup_orphans invocation
+    # Orphan must NOT be removed by cleanup_source (it has no knowledge of the source row
+    # being deleted yet; orphan cleanup is done explicitly by callers after deletion).
     orphans_after = list(
         session.exec(
             select(CalendarSyncStatusEntry).where(
@@ -131,4 +122,15 @@ def test_cleanup_source_runs_orphan_cleanup(session):
             )
         ).all()
     )
-    assert len(orphans_after) == 0
+    assert len(orphans_after) == 1
+
+    # Explicit cleanup_orphans call (as a caller would do post-deletion) removes it.
+    repo.cleanup_orphans(session)
+    orphans_final = list(
+        session.exec(
+            select(CalendarSyncStatusEntry).where(
+                CalendarSyncStatusEntry.calendar_source_id == 9999
+            )
+        ).all()
+    )
+    assert len(orphans_final) == 0


### PR DESCRIPTION
Bugs fixed:
- config.py / main.py: scheduler cycle used BACKGROUND_SYNC_DELAY_MINUTES (per-source throttle) instead of BACKGROUND_SYNC_DEFAULT_MINUTES; always use the default cycle constant for the APScheduler interval
- legacy/index.html: broken Jinja2 syntax `{ { variable } }` rendered as literal text, causing a JS SyntaxError that killed the legacy UI on load
- main.js: reason guard prevented alarm HTML refresh on periodic timer ticks; remove guard so refreshAlarmPoller always runs after new data arrives
- caldav_client.py: _same_calendar_url used substring containment, causing false-positive matches between /calendars/home and /calendars/home-work; replaced with path-segment equality via urlparse
- calendar_sync.py: force=True + CalDAV no-change response left ics_content=None, marking the sync as failed; re-fetch with sync_token=None in this case
- sync_gateway.py: ICalendarSyncGateway Protocol stub missing force param, causing Pyright errors for typed callers
- calendar_sync.py: _build_calendar_element_payloads accepted window_start, window_end, fix_icloud but immediately deleted them; removed dead params
- repository.py: cleanup_source called cleanup_orphans while source row still existed, so orphans for that source were never found; removed premature call
- calendar_sync.py / alarm_normalizer.py: _is_apple_source imported across submodule boundary as a private symbol; renamed to is_apple_source

Also adds CLAUDE.md with commands, architecture overview, and non-negotiable rules for future Claude Code sessions.