### PR TITLE
fix: Correct alarm purge, orphan cleanup, and CalDAV sync bugs from c…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,11 +40,16 @@ CALDAV_DISABLE_HTTP3=true
 # Deploy behind a reverse proxy with auth or on trusted network only.
 
 # Optional: Delay between syncing individual calendar sources during a background
-# run. Value is in minutes and may be fractional (e.g. 0.5 = 30 seconds).
-# Default: 0 (no delay).
+# run. This is only a per-source throttle between individual calendar
+# fetches within one sync cycle — it does NOT control how often the
+# scheduler runs. Value is in minutes and may be fractional (e.g. 0.5 = 30
+# seconds). Default: 0 (no delay).
 BACKGROUND_SYNC_DELAY_MINUTES=0
-# Default delay used when BACKGROUND_SYNC_DELAY_MINUTES is unset or <= 0
-# Value is in minutes. Default: 120
+# How often the background sync scheduler runs, in minutes. This is the
+# actual sync cycle period (previously, versions of this app used
+# BACKGROUND_SYNC_DELAY_MINUTES as a fallback for the cycle length when set
+# above 0; that fallback has been removed — set this value instead).
+# Default: 120
 BACKGROUND_SYNC_DEFAULT_MINUTES=120
 
 # Optional: Retention window (in days) for AlarmEvent rows. Past alarm/event

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,7 +120,9 @@ The composition root in `app/modules/loader.py` wires all modules into the FastA
 ### Alarms
 
 - Alarm dismissal state lives in `AlarmEvent`
-- Old dismissed alarms are purged after 30 days
+- `AlarmEvent` rows (dismissed or not) whose `trigger_time` is older than `ALARM_RETENTION_DAYS`
+  (default 30 days) are purged automatically on each background sync, via `POST
+  /api/v1/alarms/purge-old`, or via `espima alarms purge`
 - Simulated alarms are part of the current debug/test-support behavior
 
 ### Weather

--- a/CODEBASE_EXPLORATION_SUMMARY.md
+++ b/CODEBASE_EXPLORATION_SUMMARY.md
@@ -170,9 +170,15 @@ Schema migrations are managed by **Alembic** (`alembic/`).
 ### Alarm Display
 
 1. Dashboard refresh route injects `IAlarmsService`.
-2. Alarms module purges old dismissed alarms.
-3. Active alarms are assembled from cached calendar data and simulated alarm rows.
-4. Router converts them into template context.
+2. Active alarms are assembled from cached calendar data and simulated alarm rows (this render
+   path is read-only; it does not purge).
+3. Router converts them into template context.
+
+### Alarm Retention
+
+1. On each background sync (and via `POST /api/v1/alarms/purge-old` or `espima alarms purge`),
+   the alarms module purges `AlarmEvent` rows — dismissed or not — whose `trigger_time` is older
+   than `ALARM_RETENTION_DAYS`.
 
 ### Media Upload
 

--- a/app/config.py
+++ b/app/config.py
@@ -21,9 +21,11 @@ METEO_SYNC_INTERVAL_MINUTES = int(os.getenv("METEO_SYNC_INTERVAL_MINUTES", 15))
 INDEX_UPDATE_INTERVAL_SECONDS = int(os.getenv("INDEX_UPDATE_INTERVAL_SECONDS", 300))
 
 # Retention window (in days) for AlarmEvent rows. Past alarm/event rows whose
-# trigger_time is older than this are purged on each background sync. Also used
-# for the dismissed-alarm purge so both retention rules stay aligned.
-ALARM_RETENTION_DAYS = int(os.getenv("ALARM_RETENTION_DAYS", 30))
+# trigger_time is older than this are purged on each background sync (and by
+# `espima alarms purge`). Clamped to at least 1 day: 0 or a negative value
+# would put the purge cutoff at or after "now", deleting alarms that are
+# currently displayed or have not yet fired.
+ALARM_RETENTION_DAYS = max(1, int(os.getenv("ALARM_RETENTION_DAYS", 30)))
 
 # CalDAV / WebDAV configuration (optional)
 # Use these env vars to configure a single CalDAV account and calendar to ingest

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 # Import configuration constants
 from app.config import BACKGROUND_SYNC_DEFAULT_MINUTES
 from app.db.session_factory import SessionFactory
+from app.modules.alarms.loader import build_alarms_service
 from app.modules.alarms.rest import router as alarms_rest_router
 from app.modules.calendar.loader import build_calendar_service
 from app.modules.calendar.rest import router as calendar_rest_router
@@ -89,12 +90,19 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 
 async def background_sync_calendars() -> None:
-    """Background task to sync calendar events on configured interval."""
+    """Background task to sync calendar events on configured interval.
+
+    Calendar sync and the alarm-retention purge are independent concerns:
+    the purge must run even when there are no calendar sources configured,
+    or when sync itself fails, so the AlarmEvent table stays bounded in
+    every runtime state.
+    """
+    from app.db.engine import engine
+
+    session_factory = SessionFactory(engine)
+
     try:
         # Build calendar service via module-owned composition helper
-        from app.db.engine import engine
-
-        session_factory = SessionFactory(engine)
         calendar_service = build_calendar_service(session_factory)
         # If the calendar service exposes `get_calendars_for_ui`, use it to
         # detect an empty configuration and skip sync when there are no sources.
@@ -112,32 +120,29 @@ async def background_sync_calendars() -> None:
 
         if should_skip:
             logger.info("Background calendar sync skipped: no calendar sources configured")
-            return
-
-        result = await calendar_service.general_sync()
-        if result.alarms_skipped:
-            logger.info(
-                "Background general sync skipped alarm normalization: %s",
-                result.alarms_skip_reason,
-            )
         else:
-            logger.info(
-                "Background general sync normalized %s alarm occurrences",
-                result.normalized_alarm_count,
-            )
-
-        # Purge stale past alarm/event rows so the AlarmEvent table stays bounded.
-        try:
-            from app.modules.alarms.internal.application.service import create_alarms_service
-            from app.modules.alarms.internal.infrastructure.repository import AlarmsRepository
-
-            alarms_service = create_alarms_service(session_factory, AlarmsRepository())
-            purged = await alarms_service.purge_old_alarms()
-            logger.info("Background sync purged %s old alarm rows", purged)
-        except Exception:
-            logger.exception("Error purging old alarms during background sync")
+            result = await calendar_service.general_sync()
+            if result.alarms_skipped:
+                logger.info(
+                    "Background general sync skipped alarm normalization: %s",
+                    result.alarms_skip_reason,
+                )
+            else:
+                logger.info(
+                    "Background general sync normalized %s alarm occurrences",
+                    result.normalized_alarm_count,
+                )
     except Exception as e:
         logger.exception("Error in background calendar sync: %s", e)
+
+    # Purge stale past alarm/event rows so the AlarmEvent table stays bounded,
+    # regardless of whether the sync above ran, was skipped, or failed.
+    try:
+        alarms_service = build_alarms_service(session_factory)
+        purged = await alarms_service.purge_old_alarms()
+        logger.info("Background sync purged %s old alarm rows", purged)
+    except Exception:
+        logger.exception("Error purging old alarms during background sync")
 
 
 def _sync_period_minutes() -> float:

--- a/app/modules/alarms/api/interfaces.py
+++ b/app/modules/alarms/api/interfaces.py
@@ -32,10 +32,6 @@ class IAlarmsService(Protocol):
         """
         ...
 
-    async def purge_old_dismissed_alarms(self) -> None:
-        """Purge dismissed alarms older than the retention window."""
-        ...
-
     async def purge_old_alarms(self, retention_days: int = ALARM_RETENTION_DAYS) -> int:
         """Purge past alarm/event rows older than the retention window.
 

--- a/app/modules/alarms/api/repositories.py
+++ b/app/modules/alarms/api/repositories.py
@@ -58,24 +58,17 @@ class IAlarmsRepository(Protocol):
         """Return simulated alarms ready to fire and not dismissed."""
         ...
 
-    def list_dismissed_before(
-        self,
-        session: Session,
-        purge_before: datetime,
-    ) -> list[Any]:
-        """Return dismissed alarms older than a threshold."""
-        ...
-
-    def list_triggered_before(
+    def delete_triggered_before(
         self,
         session: Session,
         cutoff: datetime,
-    ) -> list[Any]:
-        """Return alarms whose trigger_time is older than a threshold."""
-        ...
+    ) -> int:
+        """Delete alarms whose trigger_time is older than a threshold.
 
-    def delete_alarm(self, session: Session, alarm: Any) -> None:
-        """Delete one alarm row in current transaction."""
+        Removes both dismissed and active rows in a single bulk statement so
+        stale past occurrences are purged regardless of dismissal state.
+        Returns the number of rows deleted.
+        """
         ...
 
     def list_cached_events(self, session: Session) -> list[Any]:

--- a/app/modules/alarms/internal/application/service.py
+++ b/app/modules/alarms/internal/application/service.py
@@ -485,30 +485,6 @@ class AlarmsService:
             except Exception as e:
                 logger.error("Error dismissing alarm %s: %s", alarm_uid, e)
 
-    async def purge_old_dismissed_alarms(self, session: Session | None = None) -> None:
-        """Purge dismissed alarms older than the retention window."""
-        with self._session_scope(session) as active_session:
-            try:
-                now = datetime.now(UTC)
-                purge_before = now - timedelta(days=ALARM_RETENTION_DAYS)
-                dismissed_alarms = self._repository.list_dismissed_before(
-                    active_session,
-                    purge_before,
-                )
-
-                count = len(dismissed_alarms)
-                if count > 0:
-                    logger.info(
-                        "Purging %d dismissed alarms older than %s",
-                        count,
-                        purge_before.isoformat(),
-                    )
-                    for alarm in dismissed_alarms:
-                        self._repository.delete_alarm(active_session, alarm)
-                    active_session.commit()
-            except Exception as e:
-                logger.error("Error purging old dismissed alarms: %s", e)
-
     async def purge_old_alarms(
         self,
         retention_days: int = ALARM_RETENTION_DAYS,
@@ -523,24 +499,23 @@ class AlarmsService:
             Number of alarm rows deleted.
         """
         with self._session_scope(session) as active_session:
+            cutoff = datetime.now(UTC) - timedelta(days=retention_days)
             try:
-                cutoff = datetime.now(UTC) - timedelta(days=retention_days)
-                old_alarms = self._repository.list_triggered_before(active_session, cutoff)
-
-                count = len(old_alarms)
+                count = self._repository.delete_triggered_before(active_session, cutoff)
+                active_session.commit()
                 if count > 0:
                     logger.info(
-                        "Purging %d alarm rows triggered before %s",
+                        "Purged %d alarm rows triggered before %s",
                         count,
                         cutoff.isoformat(),
                     )
-                    for alarm in old_alarms:
-                        self._repository.delete_alarm(active_session, alarm)
-                    active_session.commit()
                 return count
-            except Exception as e:
-                logger.error("Error purging old alarms: %s", e)
-                return 0
+            except Exception:
+                # Do not swallow the failure: callers (the REST endpoint, the
+                # background sync job) need to distinguish "nothing to purge"
+                # from "the purge failed".
+                logger.exception("Error purging old alarms")
+                raise
 
     async def get_debug_alarm_state(self, session: Session | None = None) -> dict[str, Any]:
         """Get cached calendar events and alarm events for debugging."""
@@ -639,7 +614,8 @@ class AlarmsService:
                 },
             ]
         else:
-            await self.purge_old_dismissed_alarms()
+            # Purging is handled by the background sync job (purge_old_alarms);
+            # rendering the alarm widget is a read-only operation.
             active_alarms = await self.get_active_alarms()
 
         return self._alarms_to_context(active_alarms, mock=mock, tz_offset=tz_offset)

--- a/app/modules/alarms/internal/infrastructure/repository.py
+++ b/app/modules/alarms/internal/infrastructure/repository.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, cast
 from uuid import UUID
 
-from sqlmodel import Session, select
+from sqlmodel import Session, delete, select
 
 from app.db.models import AlarmEvent, CalendarEvent, CalendarSource
 from app.modules.alarms.api.repositories import IAlarmsRepository
@@ -88,37 +88,20 @@ class AlarmsRepository(IAlarmsRepository):
             ).all()
         )
 
-    def list_dismissed_before(
-        self,
-        session: Session,
-        purge_before: datetime,
-    ) -> list[AlarmEvent]:
-        """Return dismissed alarms older than a threshold."""
-        dismissed_col = cast(Any, AlarmEvent.dismissed_at)
-        return list(
-            session.exec(
-                select(AlarmEvent).where(
-                    (dismissed_col.isnot(None)) & (dismissed_col < purge_before)
-                )
-            ).all()
-        )
-
-    def list_triggered_before(
+    def delete_triggered_before(
         self,
         session: Session,
         cutoff: datetime,
-    ) -> list[AlarmEvent]:
-        """Return alarms whose trigger_time is older than a threshold.
+    ) -> int:
+        """Delete alarms whose trigger_time is older than a threshold.
 
-        Includes both dismissed and active rows so stale past occurrences are
-        purged regardless of dismissal state.
+        Removes both dismissed and active rows in a single bulk statement so
+        stale past occurrences are purged regardless of dismissal state.
+        Returns the number of rows deleted.
         """
         trigger_col = cast(Any, AlarmEvent.trigger_time)
-        return list(session.exec(select(AlarmEvent).where(trigger_col < cutoff)).all())
-
-    def delete_alarm(self, session: Session, alarm: AlarmEvent) -> None:
-        """Delete one alarm row in current transaction."""
-        session.delete(alarm)
+        result = session.exec(delete(AlarmEvent).where(trigger_col < cutoff))
+        return cast(int, result.rowcount)
 
     def list_cached_events(self, session: Session) -> list[CalendarEvent]:
         """Return all cached events for debug view."""

--- a/app/modules/alarms/loader.py
+++ b/app/modules/alarms/loader.py
@@ -7,20 +7,27 @@ from fastapi import FastAPI
 from app.db.engine import engine
 from app.db.session_factory import SessionFactory
 
-from .api.interfaces import get_alarms_service
+from .api.interfaces import IAlarmsService, get_alarms_service
 from .internal.application.service import create_alarms_service
 from .internal.infrastructure.repository import AlarmsRepository
 
 logger = logging.getLogger(__name__)
 
 
+def build_alarms_service(session_factory: SessionFactory) -> IAlarmsService:
+    """Module-owned composition helper for the alarms service.
+
+    Mirrors `app.modules.calendar.loader.build_calendar_service` so callers
+    outside the module (e.g. the APScheduler background job in
+    `app/main.py`) never need to import from `internal/`.
+    """
+    return create_alarms_service(session_factory, AlarmsRepository())
+
+
 async def init(app: FastAPI) -> None:
     """Initialize alarms module dependencies."""
     session_factory = SessionFactory(engine)
-    service = create_alarms_service(
-        session_factory,
-        AlarmsRepository(),
-    )
+    service = build_alarms_service(session_factory)
     app.dependency_overrides[get_alarms_service] = lambda: service
     logger.info("Initialized alarms module")
 

--- a/app/modules/alarms/rest/router.py
+++ b/app/modules/alarms/rest/router.py
@@ -1,5 +1,6 @@
 """Atomic JSON routes for alarm operations."""
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Query
@@ -10,6 +11,8 @@ from app.config import ALARM_RETENTION_DAYS
 from app.modules.alarms.api.interfaces import IAlarmsService, get_alarms_service
 
 from .schemas import SimulateAlarmRequest
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/alarms", tags=["api-alarms"])
 
@@ -57,24 +60,21 @@ async def create_simulated_alarm(
     return JSONResponse(status_code=201, content=jsonable_encoder(alarm))
 
 
-@router.post("/purge-dismissed")
-async def purge_old_dismissed_alarms(
-    alarms_service: IAlarmsService = Depends(get_alarms_service),
-) -> JSONResponse:
-    """Purge dismissed alarms older than the retention window."""
-    await alarms_service.purge_old_dismissed_alarms()
-    purge_before = (datetime.now(UTC) - timedelta(days=ALARM_RETENTION_DAYS)).isoformat()
-    return JSONResponse(content={"status": "purged", "purge_before_utc": purge_before})
-
-
 @router.post("/purge-old")
 async def purge_old_alarms(
     retention_days: int = Query(ALARM_RETENTION_DAYS, ge=1),
     alarms_service: IAlarmsService = Depends(get_alarms_service),
 ) -> JSONResponse:
     """Purge past alarm/event rows whose trigger_time is older than retention."""
-    deleted = await alarms_service.purge_old_alarms(retention_days=retention_days)
     cutoff = (datetime.now(UTC) - timedelta(days=retention_days)).isoformat()
+    try:
+        deleted = await alarms_service.purge_old_alarms(retention_days=retention_days)
+    except Exception:
+        logger.exception("Purge-old request failed")
+        return JSONResponse(
+            status_code=500,
+            content={"status": "error", "cutoff_utc": cutoff},
+        )
     return JSONResponse(content={"status": "purged", "deleted": deleted, "cutoff_utc": cutoff})
 
 

--- a/app/modules/calendar/internal/application/service.py
+++ b/app/modules/calendar/internal/application/service.py
@@ -276,6 +276,20 @@ class CalendarService:
                 logger.exception("Failed to cleanup related rows for source %s", source_id)
 
             self._repository.delete_source(active_session, source)
+
+            # Sweep any rows left orphaned by this deletion (e.g. if
+            # cleanup_source above failed, or a concurrent sync re-inserted
+            # rows for this source between the cleanup and the delete).
+            # This is the only place in the running app that reclaims
+            # orphaned CalendarElement/CalendarSyncStatusEntry rows.
+            try:
+                if hasattr(self._repository, "cleanup_orphans"):
+                    self._repository.cleanup_orphans(active_session)
+            except Exception:
+                logger.exception(
+                    "Failed to sweep orphaned rows after deleting source %s", source_id
+                )
+
             return True
 
     async def get_sync_status(self, session: Session | None = None) -> list[SyncStatusDTO]:

--- a/app/modules/calendar/internal/infrastructure/caldav_client.py
+++ b/app/modules/calendar/internal/infrastructure/caldav_client.py
@@ -77,12 +77,39 @@ def _normalize_calendar_url(url: str) -> str:
     return url.strip().rstrip("/")
 
 
+def _path_segments(path: str) -> list[str]:
+    """Split a URL path into non-empty segments."""
+    return [segment for segment in path.split("/") if segment]
+
+
+def _is_segment_suffix(left_segments: list[str], right_segments: list[str]) -> bool:
+    """Return True when one segment list is a trailing sublist of the other.
+
+    Restricted to whole path segments so a bare calendar name or partial
+    path (e.g. CALDAV_CALENDAR="home") matches a full server href
+    (".../calendars/home") without incorrectly matching
+    ".../calendars/home-work" — that would require an exact segment
+    "home-work" == "home", which fails.
+    """
+    if not left_segments or not right_segments:
+        return False
+    shorter, longer = (
+        (left_segments, right_segments)
+        if len(left_segments) <= len(right_segments)
+        else (right_segments, left_segments)
+    )
+    return longer[len(longer) - len(shorter) :] == shorter
+
+
 def _same_calendar_url(left: str, right: str) -> bool:
     """Return True when two URLs refer to the same CalDAV calendar.
 
-    Compares full normalized URLs first, then falls back to path-segment
-    equality. Substring containment is intentionally avoided — it would
-    incorrectly match /calendars/home against /calendars/home-work.
+    Compares full normalized URLs first, then path equality, then falls back
+    to a segment-boundary suffix match so a configured partial path or
+    calendar name (CALDAV_CALENDAR="personal" or "user/personal") still
+    matches a full server href. Substring containment is intentionally
+    avoided — it would incorrectly match /calendars/home against
+    /calendars/home-work; segment-boundary comparison does not.
     """
     normalized_left = _normalize_calendar_url(left)
     normalized_right = _normalize_calendar_url(right)
@@ -92,23 +119,21 @@ def _same_calendar_url(left: str, right: str) -> bool:
         return True
     left_path = urlparse(normalized_left).path.rstrip("/")
     right_path = urlparse(normalized_right).path.rstrip("/")
-    return bool(left_path and right_path and left_path == right_path)
+    if left_path and right_path and left_path == right_path:
+        return True
+    return _is_segment_suffix(_path_segments(left_path), _path_segments(right_path))
 
 
 def _find_matching_calendar(calendars: list[Any], target_calendar: str) -> Any | None:
     """Find one discovered calendar matching the requested URL/path."""
     normalized_target = _normalize_calendar_url(target_calendar)
-    target_path = urlparse(normalized_target).path.rstrip("/")
 
     for calendar in calendars:
         try:
             href = getattr(calendar, "url", None) or getattr(calendar, "href", None)
             href_str = str(href or calendar)
             normalized_href = _normalize_calendar_url(href_str)
-            href_path = urlparse(normalized_href).path.rstrip("/")
             if _same_calendar_url(normalized_target, normalized_href):
-                return calendar
-            if target_path and href_path and target_path == href_path:
                 return calendar
         except Exception:
             continue

--- a/app/modules/calendar/internal/infrastructure/calendar_sync.py
+++ b/app/modules/calendar/internal/infrastructure/calendar_sync.py
@@ -1252,6 +1252,11 @@ class CalendarService:
                 ):
                     is_caldav = True
                     caldav_result = prefetched_caldav_result
+                    # On a forced resync, skip the sync token so the server
+                    # returns full content in this one request instead of
+                    # correctly reporting "no changes" and requiring a second,
+                    # tokenless round trip.
+                    fetch_sync_token = None if force else sync_status.sync_token
                     # If a prefetched batch result exists but indicated the fetch
                     # did not succeed (for example network error), and the user
                     # requested a forced resync, attempt a per-source fetch with
@@ -1260,7 +1265,7 @@ class CalendarService:
                     if caldav_result is None:
                         caldav_result = await fetch_caldav_calendar_ics_with_metadata(
                             calendar_url=source.url,
-                            sync_token=sync_status.sync_token,
+                            sync_token=fetch_sync_token,
                             fail_on_error=True,
                         )
                     elif not getattr(caldav_result, "fetch_succeeded", True) and force:
@@ -1273,7 +1278,7 @@ class CalendarService:
                         # raise CalDAVFetchError on persistent failures.
                         caldav_result = await fetch_caldav_calendar_ics_with_metadata(
                             calendar_url=source.url,
-                            sync_token=sync_status.sync_token,
+                            sync_token=fetch_sync_token,
                             fail_on_error=True,
                         )
                     next_sync_token = caldav_result.sync_token or sync_status.sync_token
@@ -1316,31 +1321,6 @@ class CalendarService:
                         ]
                         if force and not changed:
                             changed = True
-                        # When force=True and CalDAV correctly reports no changes,
-                        # content is None (the server did not send a full payload).
-                        # Re-fetch without a sync token to obtain the full content.
-                        if force and ics_content is None:
-                            logger.info(
-                                "Force requested but CalDAV reported no changes for source %s (%s);"
-                                " re-fetching without sync token.",
-                                source.id,
-                                source.label,
-                            )
-                            fresh_result = await fetch_caldav_calendar_ics_with_metadata(
-                                calendar_url=source.url,
-                                sync_token=None,
-                                fail_on_error=False,
-                            )
-                            ics_content = fresh_result.content
-                            raw_elements = [
-                                {
-                                    "uid": el.uid,
-                                    "href": el.href,
-                                    "etag": el.etag,
-                                    "raw_ics": el.raw_ics,
-                                }
-                                for el in fresh_result.elements
-                            ]
                 else:
                     ics_content = await CalendarService.fetch_ics(source.url)
                     if ics_content is not None:
@@ -1499,8 +1479,15 @@ class CalendarService:
                     caldav_requests.append((source.id, source.url, sync_status.sync_token))
 
                 if caldav_requests:
+                    # On a forced resync, skip the sync token so the server
+                    # returns full content on this one request instead of
+                    # reporting "no changes" and requiring a second, tokenless
+                    # round trip (see the per-source fetch below).
                     batch_results = await fetch_caldav_calendars_with_metadata(
-                        [(source_url, sync_token) for _, source_url, sync_token in caldav_requests],
+                        [
+                            (source_url, None if force else sync_token)
+                            for _, source_url, sync_token in caldav_requests
+                        ],
                         fail_on_error=False,
                     )
                     prefetched_caldav_results = {
@@ -1566,18 +1553,16 @@ class CalendarService:
         # (see AlarmsService.purge_old_alarms, invoked after general_sync).
 
         logger.info("Background sync completed.")
-        # Log when the next background update is planned using configured delay
+        # Log when the next background update is planned. The scheduler's
+        # cycle period is always BACKGROUND_SYNC_DEFAULT_MINUTES;
+        # BACKGROUND_SYNC_DELAY_MINUTES is only the per-source throttle
+        # between individual calendar fetches within one sync run.
         try:
-            delay_minutes = (
-                BACKGROUND_SYNC_DELAY_MINUTES
-                if BACKGROUND_SYNC_DELAY_MINUTES and BACKGROUND_SYNC_DELAY_MINUTES > 0
-                else BACKGROUND_SYNC_DEFAULT_MINUTES
-            )
-            next_run = datetime.now(UTC) + timedelta(minutes=delay_minutes)
+            next_run = datetime.now(UTC) + timedelta(minutes=BACKGROUND_SYNC_DEFAULT_MINUTES)
             logger.info(
                 "Next background sync planned at %s (in %.1f minutes)",
                 next_run.isoformat(),
-                delay_minutes,
+                float(BACKGROUND_SYNC_DEFAULT_MINUTES),
             )
         except Exception:
             logger.debug("Unable to compute next background sync time")

--- a/app/modules/calendar/internal/infrastructure/repository.py
+++ b/app/modules/calendar/internal/infrastructure/repository.py
@@ -1,6 +1,7 @@
 """Calendar repository adapter for SQLModel persistence."""
 
 from datetime import datetime
+from typing import Any, cast
 
 from sqlmodel import Session, select
 
@@ -91,14 +92,7 @@ class CalendarRepository(ICalendarRepository):
 
         Returns tuple of deleted counts: (sync_status_count, calendar_elements_count, alarm_events_count).
         """
-        from sqlmodel import select
-
-        from app.db.models import (
-            AlarmEvent,
-            CalendarElement,
-            CalendarSource,
-            CalendarSyncStatusEntry,
-        )
+        from app.db.models import AlarmEvent
 
         active_sources = list(session.exec(select(CalendarSource.id)).all())
         # SQLModel may return a list of scalars or tuples depending on the query;
@@ -110,31 +104,36 @@ class CalendarRepository(ICalendarRepository):
             else:
                 active_ids.add(row)
 
+        # A row is orphaned when it has a (non-null) source id that does not
+        # belong to any surviving CalendarSource. NULL is never orphaned here:
+        # for AlarmEvent it marks a simulated alarm (intentionally source-less,
+        # see list_ready_simulated_alarms), and the other two tables never have
+        # a null source id at all. This must hold even when active_ids is
+        # empty (e.g. the last calendar source was just deleted) — otherwise
+        # every remaining row would be skipped as "not orphaned" instead of
+        # correctly being swept, or simulated alarms would be wrongly deleted.
+        def _is_orphan(col: Any) -> Any:
+            if active_ids:
+                return col.isnot(None) & ~col.in_(list(active_ids))
+            return col.isnot(None)
+
         statuses = list(
             session.exec(
                 select(CalendarSyncStatusEntry).where(
-                    (CalendarSyncStatusEntry.calendar_source_id.is_(None))
-                    if not active_ids
-                    else (~CalendarSyncStatusEntry.calendar_source_id.in_(list(active_ids)))
+                    _is_orphan(cast(Any, CalendarSyncStatusEntry.calendar_source_id))
                 )
             ).all()
         )
         elements = list(
             session.exec(
                 select(CalendarElement).where(
-                    (CalendarElement.calendar_source_id.is_(None))
-                    if not active_ids
-                    else (~CalendarElement.calendar_source_id.in_(list(active_ids)))
+                    _is_orphan(cast(Any, CalendarElement.calendar_source_id))
                 )
             ).all()
         )
         alarms = list(
             session.exec(
-                select(AlarmEvent).where(
-                    (AlarmEvent.calendar_source_id.is_(None))
-                    if not active_ids
-                    else (~AlarmEvent.calendar_source_id.in_(list(active_ids)))
-                )
+                select(AlarmEvent).where(_is_orphan(cast(Any, AlarmEvent.calendar_source_id)))
             ).all()
         )
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -87,8 +87,14 @@
             return '/components/alarm?tz_offset=' + encodeURIComponent(String(tzOffset));
         }
 
-        function refreshAlarmPoller(tzOffset) {
-            lastAlarmContent = '';
+        function refreshAlarmPoller(tzOffset, force) {
+            // Only force-clear the anti-flicker dedup cache when the caller
+            // knows content must change (e.g. right after a dismiss). Callers
+            // that just want to check for updates should not reset it, or
+            // every refresh would re-swap identical content.
+            if (force) {
+                lastAlarmContent = '';
+            }
             var target = '#alarm-poller';
             var path = buildAlarmRefreshPath(tzOffset);
             if (window.htmx && typeof window.htmx.ajax === 'function') {
@@ -229,7 +235,7 @@
             }, waitMs);
         }
 
-        function fetchDayPayload(_reason) {
+        function fetchDayPayload(reason) {
             var tzOffset = getBrowserTzOffset();
             var url = '/api/v1/alarms/today?tz_offset=' + encodeURIComponent(String(tzOffset));
             fetch(url)
@@ -247,7 +253,14 @@
                     } catch (e) {
                         console.error('formatAlarmTimes error', e);
                     }
-                    refreshAlarmPoller(tzOffset);
+                    // Only refresh here on init/cross-tab sync. Scheduled and
+                    // alarm-trigger cycles already get their alarm refresh
+                    // from scheduleNextAlarmCheck (and, for alarm-trigger,
+                    // from the timer callback itself) — refreshing
+                    // unconditionally here would race those calls.
+                    if (reason === 'init' || reason === 'sync-event') {
+                        refreshAlarmPoller(tzOffset);
+                    }
                     scheduleNextAlarmCheck();
                     scheduleNextDayPayloadFetch();
                 })
@@ -333,7 +346,7 @@
                 }
                 return response.json();
             }).then(function () {
-                refreshAlarmPoller(tzOffset);
+                refreshAlarmPoller(tzOffset, true);
             }).catch(function () {
                 // Keep behavior unobtrusive in slideshow mode.
             });

--- a/espima/cli.py
+++ b/espima/cli.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from alembic import command
+from app.config import ALARM_RETENTION_DAYS
 
 load_dotenv()
 
@@ -83,13 +84,9 @@ def _build_alarms_service() -> Any:
     """Build alarms service using the app's module composition wiring."""
     from app.db.engine import engine
     from app.db.session_factory import SessionFactory
-    from app.modules.alarms.internal.application.service import create_alarms_service
-    from app.modules.alarms.internal.infrastructure.repository import AlarmsRepository
+    from app.modules.alarms.loader import build_alarms_service
 
-    return create_alarms_service(
-        SessionFactory(engine),
-        AlarmsRepository(),
-    )
+    return build_alarms_service(SessionFactory(engine))
 
 
 def _initialize_database() -> None:
@@ -686,9 +683,10 @@ def alarms_sync(
 @alarms_app.command("purge")
 def alarms_purge(
     retention_days: int = typer.Option(
-        default=30,
+        default=ALARM_RETENTION_DAYS,
         min=1,
-        help="Delete alarm rows whose trigger_time is older than this many days.",
+        help="Delete alarm rows whose trigger_time is older than this many days. "
+        "Defaults to ALARM_RETENTION_DAYS.",
     ),
 ) -> None:
     """Purge stale past alarm/event rows from alarmevent."""

--- a/tests/test_alarm_purge_old.py
+++ b/tests/test_alarm_purge_old.py
@@ -1,12 +1,15 @@
 """Tests for time-based purging of stale AlarmEvent rows."""
 
+import importlib
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
-from sqlmodel import select
+from sqlmodel import Session, select
 
 from app.db.models import AlarmEntryType, AlarmEvent
+from app.main import app as fastapi_app
+from app.modules.alarms.api.interfaces import get_alarms_service
 from app.modules.alarms.internal.application.service import create_alarms_service
 from app.modules.alarms.internal.infrastructure.repository import AlarmsRepository
 
@@ -22,7 +25,7 @@ def _make_alarm(*, days_offset: int, dismissed: bool = False) -> AlarmEvent:
     )
 
 
-def test_list_triggered_before_returns_only_old_rows(session):
+def test_delete_triggered_before_removes_only_old_rows(session):
     cutoff = datetime.now(UTC) - timedelta(days=30)
     old = _make_alarm(days_offset=-60)
     recent = _make_alarm(days_offset=-5)
@@ -30,10 +33,13 @@ def test_list_triggered_before_returns_only_old_rows(session):
     session.add_all([old, recent, future])
     session.commit()
 
-    result = AlarmsRepository().list_triggered_before(session, cutoff)
+    deleted = AlarmsRepository().delete_triggered_before(session, cutoff)
+    session.commit()
 
-    ids = {alarm.id for alarm in result}
-    assert ids == {old.id}
+    assert deleted == 1
+    session.expire_all()
+    remaining = {alarm.id for alarm in session.exec(select(AlarmEvent)).all()}
+    assert remaining == {recent.id, future.id}
 
 
 @pytest.mark.anyio
@@ -91,3 +97,45 @@ def test_api_purge_old_endpoint_purges_and_reports(client, session):
     session.expire_all()
     assert session.get(AlarmEvent, old_id) is None
     assert session.get(AlarmEvent, future_id) is not None
+
+
+def test_alarm_retention_days_clamped_to_minimum_one(monkeypatch):
+    """0 or a negative ALARM_RETENTION_DAYS would put the purge cutoff at or
+    after "now", deleting currently-displayed or not-yet-fired alarms."""
+    cfg = importlib.import_module("app.config")
+    try:
+        for raw_value in ("0", "-7"):
+            monkeypatch.setenv("ALARM_RETENTION_DAYS", raw_value)
+            importlib.reload(cfg)
+            assert cfg.ALARM_RETENTION_DAYS == 1
+    finally:
+        monkeypatch.delenv("ALARM_RETENTION_DAYS", raising=False)
+        importlib.reload(cfg)
+
+
+class _FailingAlarmsRepository(AlarmsRepository):
+    """Repository double that always fails, to exercise purge error paths."""
+
+    def delete_triggered_before(self, session: Session, cutoff: datetime) -> int:
+        raise RuntimeError("simulated database failure")
+
+
+@pytest.mark.anyio
+async def test_purge_old_alarms_propagates_failure(session_factory):
+    """A DB failure during purge must not be reported as "0 rows purged" —
+    callers need to distinguish "nothing to purge" from "the purge failed"."""
+    service = create_alarms_service(session_factory, _FailingAlarmsRepository())
+
+    with pytest.raises(RuntimeError):
+        await service.purge_old_alarms()
+
+
+def test_api_purge_old_endpoint_returns_500_on_failure(client, session_factory):
+    fastapi_app.dependency_overrides[get_alarms_service] = lambda: create_alarms_service(
+        session_factory, _FailingAlarmsRepository()
+    )
+
+    response = client.post("/api/v1/alarms/purge-old")
+
+    assert response.status_code == 500
+    assert response.json()["status"] == "error"

--- a/tests/test_api_alarms.py
+++ b/tests/test_api_alarms.py
@@ -115,20 +115,22 @@ def test_api_dismiss_alarm_mock_mode_is_noop(client):
     assert response.json()["status"] == "mock-noop"
 
 
-def test_api_purge_old_dismissed_alarms_returns_json_and_purges(client, session):
-    old_alarm = AlarmEvent(
+def test_api_purge_old_endpoint_purges_dismissed_and_active_rows(client, session):
+    """purge-old subsumes the retired purge-dismissed endpoint: it purges any
+    stale row by trigger_time, whether dismissed or not."""
+    old_dismissed = AlarmEvent(
         id=uuid4(),
         trigger_time=datetime.now(UTC) - timedelta(days=60),
         dismissed_at=datetime.now(UTC) - timedelta(days=31),
     )
-    session.add(old_alarm)
+    session.add(old_dismissed)
     session.commit()
-    old_alarm_id = old_alarm.id
+    old_dismissed_id = old_dismissed.id
 
-    response = client.post("/api/v1/alarms/purge-dismissed")
+    response = client.post("/api/v1/alarms/purge-old")
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/json")
     assert response.json()["status"] == "purged"
 
     session.expire_all()
-    assert session.get(AlarmEvent, old_alarm_id) is None
+    assert session.get(AlarmEvent, old_dismissed_id) is None

--- a/tests/test_api_calendar.py
+++ b/tests/test_api_calendar.py
@@ -1,6 +1,6 @@
 from sqlmodel import select
 
-from app.db.models import CalendarSource
+from app.db.models import CalendarSource, CalendarSyncStatusEntry
 
 
 def test_api_create_calendar_source_returns_json_and_persists(client, session):
@@ -36,6 +36,33 @@ def test_api_delete_calendar_source(client, session):
 
     session.expire_all()
     assert session.get(CalendarSource, source_id) is None
+
+
+def test_api_delete_calendar_source_sweeps_orphans(client, session):
+    """Deleting a source is the only production code path that reclaims rows
+    orphaned by a prior failed/partial cleanup — it must sweep them, not just
+    delete the target source's own rows."""
+    source = CalendarSource(
+        label="Delete Me Too", url="https://example.com/delete2.ics", color="#334455"
+    )
+    session.add(source)
+    session.commit()
+    session.refresh(source)
+    source_id = source.id
+
+    # A row left orphaned by an earlier failure/deletion (no matching source).
+    orphan_status = CalendarSyncStatusEntry(calendar_source_id=999999, sync_token="orphan")
+    session.add(orphan_status)
+    session.commit()
+
+    response = client.delete(f"/api/v1/calendar/sources/{source_id}")
+    assert response.status_code == 204
+
+    session.expire_all()
+    remaining_orphans = session.exec(
+        select(CalendarSyncStatusEntry).where(CalendarSyncStatusEntry.calendar_source_id == 999999)
+    ).all()
+    assert remaining_orphans == []
 
 
 def test_api_list_calendar_sources_and_sync_status_return_json(client, session):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,3 +42,73 @@ async def test_background_sync_calendars_runs_general_sync(monkeypatch):
     await main.background_sync_calendars()
 
     assert dummy_service.called is True
+
+
+class _DummyAlarmsService:
+    def __init__(self) -> None:
+        self.purge_called = False
+
+    async def purge_old_alarms(self):
+        self.purge_called = True
+        return 0
+
+
+@pytest.mark.anyio
+async def test_background_sync_purges_alarms_even_with_no_calendar_sources(monkeypatch):
+    """The alarm-retention purge must run even when there are no configured
+    calendar sources, otherwise stale rows never get cleaned up on an
+    instance with no calendars configured."""
+    from app import main
+
+    class DummyCalendarService:
+        def __init__(self) -> None:
+            self.general_sync_called = False
+
+        async def get_calendars_for_ui(self):
+            return {"sources": []}
+
+        async def general_sync(self):
+            self.general_sync_called = True
+
+            class Result:
+                alarms_skipped = True
+                alarms_skip_reason = "test"
+                normalized_alarm_count = 0
+
+            return Result()
+
+    dummy_calendar_service = DummyCalendarService()
+    dummy_alarms_service = _DummyAlarmsService()
+
+    monkeypatch.setattr(
+        main, "build_calendar_service", lambda _session_factory: dummy_calendar_service
+    )
+    monkeypatch.setattr(main, "build_alarms_service", lambda _session_factory: dummy_alarms_service)
+
+    await main.background_sync_calendars()
+
+    assert dummy_calendar_service.general_sync_called is False
+    assert dummy_alarms_service.purge_called is True
+
+
+@pytest.mark.anyio
+async def test_background_sync_purges_alarms_even_when_general_sync_fails(monkeypatch):
+    """The alarm-retention purge must run even when calendar sync itself
+    raises (e.g. an unreachable CalDAV server), otherwise a persistently
+    failing sync silently disables the purge forever."""
+    from app import main
+
+    class DummyCalendarService:
+        async def general_sync(self):
+            raise RuntimeError("simulated sync failure")
+
+    dummy_alarms_service = _DummyAlarmsService()
+
+    monkeypatch.setattr(
+        main, "build_calendar_service", lambda _session_factory: DummyCalendarService()
+    )
+    monkeypatch.setattr(main, "build_alarms_service", lambda _session_factory: dummy_alarms_service)
+
+    await main.background_sync_calendars()
+
+    assert dummy_alarms_service.purge_called is True

--- a/tests/test_caldav_adapter.py
+++ b/tests/test_caldav_adapter.py
@@ -1,6 +1,66 @@
 import importlib
 
 
+def test_same_calendar_url_exact_url_matches():
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+    assert client._same_calendar_url(
+        "https://host/remote.php/dav/calendars/user/personal/",
+        "https://host/remote.php/dav/calendars/user/personal",
+    )
+
+
+def test_same_calendar_url_full_path_matches():
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+    assert client._same_calendar_url(
+        "/remote.php/dav/calendars/user/personal",
+        "https://host/remote.php/dav/calendars/user/personal/",
+    )
+
+
+def test_same_calendar_url_partial_path_suffix_matches():
+    """CALDAV_CALENDAR may be a partial path (config.py: 'exact calendar URL
+    or path'); it should still match a full server href on segment
+    boundaries."""
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+    assert client._same_calendar_url(
+        "user/personal",
+        "https://host/remote.php/dav/calendars/user/personal/",
+    )
+
+
+def test_same_calendar_url_bare_name_suffix_matches():
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+    assert client._same_calendar_url(
+        "personal",
+        "https://host/remote.php/dav/calendars/user/personal/",
+    )
+
+
+def test_same_calendar_url_does_not_match_on_partial_segment():
+    """Suffix matching must respect segment boundaries: 'home' must not
+    match 'home-work'."""
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+    assert not client._same_calendar_url(
+        "home",
+        "https://host/calendars/home-work/",
+    )
+
+
+def test_find_matching_calendar_prefers_suffix_match_and_rejects_similar_name():
+    client = importlib.import_module("app.modules.calendar.internal.infrastructure.caldav_client")
+
+    class _Cal:
+        def __init__(self, url):
+            self.url = url
+
+    home_work = _Cal("https://host/remote.php/dav/calendars/user/home-work/")
+    personal = _Cal("https://host/remote.php/dav/calendars/user/personal/")
+    calendars = [home_work, personal]
+
+    assert client._find_matching_calendar(calendars, "personal") is personal
+    assert client._find_matching_calendar(calendars, "home") is None
+
+
 def test_fetch_caldav_disabled(monkeypatch):
     """When CalDAV is disabled via config, the adapter returns None quickly."""
     cfg = importlib.import_module("app.config")

--- a/tests/test_calendar_repository_cleanup.py
+++ b/tests/test_calendar_repository_cleanup.py
@@ -1,5 +1,7 @@
 """Tests for calendar repository cleanup behaviors."""
 
+from datetime import UTC, datetime, timedelta
+
 from sqlmodel import select
 
 from app.db.models import (
@@ -80,6 +82,49 @@ def test_cleanup_orphans_deletes_orphan_rows(session):
     assert len(remaining_statuses) == 1
     assert len(remaining_elements) == 1
     assert len(remaining_alarms) == 1
+
+
+def test_cleanup_orphans_sweeps_all_source_rows_when_no_sources_remain(session):
+    """When there are zero CalendarSource rows left (e.g. the last calendar
+    was just deleted), any row with a non-null calendar_source_id is
+    necessarily orphaned and must still be swept — not skipped because the
+    "active ids" set happens to be empty."""
+    repo = CalendarRepository()
+
+    orphan_status = CalendarSyncStatusEntry(calendar_source_id=999999, sync_token="orphan")
+    orphan_element = CalendarElement(
+        calendar_source_id=999999,
+        uid="evt-orphan",
+        raw_ics="BEGIN:VCALENDAR\nEND:VCALENDAR\n",
+    )
+    orphan_alarm = AlarmEvent(trigger_time=orphan_element.created_at, calendar_source_id=999999)
+    session.add_all([orphan_status, orphan_element, orphan_alarm])
+    session.commit()
+
+    deleted_statuses, deleted_elements, deleted_alarms = repo.cleanup_orphans(session)
+
+    assert deleted_statuses == 1
+    assert deleted_elements == 1
+    assert deleted_alarms == 1
+
+
+def test_cleanup_orphans_preserves_simulated_alarms_when_no_sources_remain(session):
+    """Simulated alarms (calendar_source_id is None) are never orphans,
+    regardless of how many CalendarSource rows exist — cleanup_orphans must
+    not delete them even when the active-sources set is empty."""
+    repo = CalendarRepository()
+
+    simulated_alarm = AlarmEvent(
+        trigger_time=datetime.now(UTC) + timedelta(minutes=5), calendar_source_id=None
+    )
+    session.add(simulated_alarm)
+    session.commit()
+    simulated_alarm_id = simulated_alarm.id
+
+    repo.cleanup_orphans(session)
+
+    session.expire_all()
+    assert session.get(AlarmEvent, simulated_alarm_id) is not None
 
 
 def test_cleanup_source_does_not_run_orphan_cleanup(session):

--- a/tests/test_calendar_service.py
+++ b/tests/test_calendar_service.py
@@ -116,6 +116,63 @@ def test_sync_calendar_events_success(session):
     assert status.sync_status == CalendarSyncStatus.SUCCESS
 
 
+def test_force_sync_makes_single_tokenless_fetch_when_caldav_reports_no_changes(
+    session, monkeypatch
+):
+    """A forced resync of an unchanged CalDAV source must fetch once, with no
+    sync token, so the server returns full content immediately — not fetch
+    with the stored token (getting "no changes") and then re-fetch a second
+    time without a token."""
+    from app.modules.calendar.internal.infrastructure import caldav_client
+
+    now = datetime.now(UTC)
+    start = now + timedelta(hours=1)
+    end = now + timedelta(hours=2)
+    ics_content = _build_ics(start, end)
+
+    source = CalendarSource(label="Test", url="https://caldav.example.com/cal/1")
+    session.add(source)
+    session.commit()
+    session.refresh(source)
+
+    element = caldav_client.CalDAVElement(
+        uid="evt-1",
+        href="https://caldav.example.com/cal/1/evt-1.ics",
+        etag="etag-1",
+        raw_ics=ics_content,
+    )
+    call_count = {"n": 0}
+
+    async def _fake_fetch(*, calendar_url: str, sync_token: str | None, fail_on_error: bool):
+        call_count["n"] += 1
+        assert sync_token is None
+        return caldav_client.CalDAVFetchResult(
+            content=ics_content,
+            sync_token="new-token",
+            changed=False,
+            fetch_succeeded=True,
+            elements=[element],
+        )
+
+    monkeypatch.setattr(caldav_client, "fetch_caldav_calendar_ics_with_metadata", _fake_fetch)
+
+    report = asyncio.run(
+        CalendarService._sync_single_source(
+            session,
+            source,
+            now,
+            now,
+            now,
+            prefetched_caldav_result=None,
+            use_caldav=True,
+            force=True,
+        )
+    )
+
+    assert call_count["n"] == 1
+    assert report.sync_succeeded is True
+
+
 def test_sync_calendar_events_failure(session):
     source = CalendarSource(label="Test", url="webcal://example.com/test.ics")
     session.add(source)

--- a/tests/test_espima_cli.py
+++ b/tests/test_espima_cli.py
@@ -109,6 +109,9 @@ class DummyCalendarService:
 class DummyAlarmsService:
     """Minimal async service mock for espima alarms commands."""
 
+    def __init__(self) -> None:
+        self.purge_retention_days: int | None = None
+
     async def get_debug_alarm_state(self) -> dict[str, list[dict[str, str | int | None]]]:
         return {
             "alarm_events": [
@@ -121,6 +124,10 @@ class DummyAlarmsService:
                 }
             ]
         }
+
+    async def purge_old_alarms(self, retention_days: int) -> int:
+        self.purge_retention_days = retention_days
+        return 3
 
 
 def test_root_help_shows_command_groups() -> None:
@@ -291,6 +298,41 @@ def test_sync_runs_general_sync(monkeypatch) -> None:
     assert service.last_normalize_start_date == date(2026, 1, 15)
     assert service.last_normalize_days == 14
     assert "General sync completed" in result.stdout
+
+
+def test_alarms_purge_option_default_is_bound_to_alarm_retention_days() -> None:
+    """The --retention-days option must default to app.config.ALARM_RETENTION_DAYS,
+    not a hardcoded literal, so it stays consistent with the background purge
+    and the REST endpoint regardless of what an operator sets that env var to."""
+    import inspect
+
+    sig = inspect.signature(cli.alarms_purge)
+    option_info = sig.parameters["retention_days"].default
+
+    assert option_info.default == cli.ALARM_RETENTION_DAYS
+
+
+def test_alarms_purge_uses_configured_retention_when_no_flag_given(monkeypatch) -> None:
+    """Invoking with no flag should purge using ALARM_RETENTION_DAYS."""
+    service = DummyAlarmsService()
+    monkeypatch.setattr("espima.cli._build_alarms_service", lambda: service)
+
+    result = runner.invoke(cli.app, ["alarms", "purge"])
+
+    assert result.exit_code == 0
+    assert service.purge_retention_days == cli.ALARM_RETENTION_DAYS
+    assert "Purged old alarm rows" in result.stdout
+
+
+def test_alarms_purge_accepts_explicit_retention_days(monkeypatch) -> None:
+    """An explicit --retention-days flag should override the config default."""
+    service = DummyAlarmsService()
+    monkeypatch.setattr("espima.cli._build_alarms_service", lambda: service)
+
+    result = runner.invoke(cli.app, ["alarms", "purge", "--retention-days", "7"])
+
+    assert result.exit_code == 0
+    assert service.purge_retention_days == 7
 
 
 def test_alarms_list_shows_rows(monkeypatch) -> None:

--- a/tests/test_multi_alarm.py
+++ b/tests/test_multi_alarm.py
@@ -97,8 +97,10 @@ END:VCALENDAR"""
     assert "2:shared-uid" in uids
 
 
-def test_purge_old_dismissed_alarms(client, session):
-    """Verify dismissed alarms older than 30 days are purged."""
+def test_rendering_alarm_widget_does_not_purge(client, session):
+    """The alarm widget render path is read-only: purging stale rows is the
+    background sync job's responsibility (AlarmsService.purge_old_alarms),
+    not a side effect of GET /components/alarm."""
     old_alarm = AlarmEvent(
         calendar_event_uid="old-dismissed",
         trigger_time=datetime.now() - timedelta(days=60),
@@ -110,7 +112,8 @@ def test_purge_old_dismissed_alarms(client, session):
     response = client.get("/components/alarm?tz_offset=0")
     assert response.status_code == 200
 
+    session.expire_all()
     remaining = session.exec(
         select(AlarmEvent).where(AlarmEvent.calendar_event_uid == "old-dismissed")
     ).all()
-    assert remaining == []
+    assert len(remaining) == 1


### PR DESCRIPTION
…ode review

Ensures the alarm-retention purge runs on every background sync regardless of calendar source state, honors ALARM_RETENTION_DAYS consistently across the CLI/REST/background paths, surfaces purge failures instead of reporting false success, restores orphan-row cleanup after source deletion (and fixes a related cleanup_orphans bug that mishandled the zero-active-sources case), restores safe partial-path CalDAV calendar matching, fixes a stale scheduler log, and removes a duplicate-request race in the frontend alarm poller. Also consolidates the two overlapping alarm-purge code paths into one and switches it to a single bulk delete.